### PR TITLE
Make LaTeX block in display mode without background and centered

### DIFF
--- a/frontend/css/app.scss
+++ b/frontend/css/app.scss
@@ -395,7 +395,7 @@
                 }
 
                 //Content blocks
-                code, pre, blockquote, .latex.block{
+                code, pre, blockquote {
                     background:$colorBackgroundLight;
                 }
                 p, pre, blockquote, .latex.block{
@@ -447,7 +447,6 @@
                     }
                 }
                 .MathJax_Display{ //Block
-                    text-align: left!important;
                     margin:0;
                     >.MathJax{
                         background:none; margin:0;


### PR DESCRIPTION
Hey @nicbou, I think that display blocks should be centered and with default background. Display block is something that you want to mark off as important and big (important) part of your note. Also, this background doesn't look good with LaTeX. :smiley: 
