### PR TITLE
Don't sanitize HTML

### DIFF
--- a/frontend/js/directives/preview.js
+++ b/frontend/js/directives/preview.js
@@ -49,7 +49,7 @@ angular.module('notes.ui').directive("preview", function ($rootScope) {
                             }
                             return hljs.highlightAuto(code).value;
                         }, //Code highlighting
-                        sanitize: true,
+                        sanitize: false,
                         renderer: customRenderer,
                     }
                 ));


### PR DESCRIPTION
Hey @nicbou, I think that not sanitizing HTML is actually usefull when writing notes. Here is an example:

```
| Tables        | Are           | Cool  |
| ------------- |:-------------:| -----:|
| col 3 is      | right-aligned | $1600 |
| col 2 is      | centered      |   $12 |
| zebra stripes | are neat      |    $1 |
<br>
There must be at least 3 dashes separating each header cell.
The outer pipes (|) are optional, and you don't need to make the 
raw Markdown line up prettily. You can also use inline Markdown.
```

Without `<br>` tag, text below this table would be "merged" with it. There are other use cases for not sanitizing HTML. :smile: 
