### PR TITLE
Fixing Image drop for Firefox and small refactor

### DIFF
--- a/frontend/js/directives/imagedrop.js
+++ b/frontend/js/directives/imagedrop.js
@@ -1,34 +1,34 @@
 angular.module('notes.ui').directive("imagedrop", function ($parse, $document) {
+    var isImageDrag = function (e) {
+        return e.dataTransfer.types[0] === 'Files' || e.dataTransfer.types[0] === 'application/x-moz-file';
+    };
+
+    //When an item is dragged over the document
+    var onDragOver = function (e) {
+        e.preventDefault();
+
+        if (isImageDrag(e)) {
+            angular.element($document[0].body).addClass("drag-over");
+        }
+    };
+
+    //When the user leaves the window, cancels the drag or drops the item
+    var onDragEnd = function (e) {
+        e.preventDefault();
+        angular.element($document[0].body).removeClass("drag-over");
+    };
+
+    //When a file is dropped
+    var loadFile = function (file, scope, onImageDrop) {
+        scope.uploadedFile = file;
+        scope.$apply(onImageDrop(scope));
+    };
+
     return {
         restrict: "A",
         link: function (scope, element, attrs) {
             var onImageDrop = $parse(attrs.onImageDrop);
 
-            var isImageDrag = function(e){
-                return e.dataTransfer.types[0] === 'Files';
-            };
- 
-            //When an item is dragged over the document
-            var onDragOver = function (e) {
-                e.preventDefault();
-
-                if(isImageDrag(e)){
-                    angular.element($document[0].body).addClass("drag-over");
-                }
-            };
- 
-            //When the user leaves the window, cancels the drag or drops the item
-            var onDragEnd = function (e) {
-                e.preventDefault();
-                angular.element($document[0].body).removeClass("drag-over");
-            };
- 
-            //When a file is dropped
-            var loadFile = function (file) {
-                scope.uploadedFile = file;
-                scope.$apply(onImageDrop(scope));
-            };
- 
             //Dragging begins on the document
             $document.bind("dragover", onDragOver);
             
@@ -36,7 +36,7 @@ angular.module('notes.ui').directive("imagedrop", function ($parse, $document) {
             element.bind("dragleave", onDragEnd)
                    .bind("drop", function (e) {
                        onDragEnd(e);
-                       loadFile(e.dataTransfer.files[0]);
+                       loadFile(e.dataTransfer.files[0], scope, onImageDrop);
                    });
         }
     };


### PR DESCRIPTION
Fixing Image drop for Firefox.
Firefox pass as first element of File type "application/x-moz-file" not a "Files". 
