### PR TITLE
Image paste upload

### DIFF
--- a/frontend/js/directives/codemirror.js
+++ b/frontend/js/directives/codemirror.js
@@ -61,6 +61,21 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
     if (angular.isFunction(codemirrorOptions.onLoad)) {
       codemirrorOptions.onLoad(codemirror);
     }
+
+    // Pasting images support
+    new Paster(codemirror.getWrapperElement(),
+        function (data) {
+          if (data instanceof Blob) {
+            scope.uploadedFile = data;
+            scope.uploadImage();
+          } else {
+            codemirror.replaceSelection('![](' + data + ')')
+          }
+          codemirror.focus();
+        }, function (string) {
+          codemirror.focus();
+          codemirror.replaceSelection(string);
+        });
   }
 
   function newCodemirrorEditor(iElement, codemirrorOptions) {
@@ -147,4 +162,183 @@ function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
     });
   }
 
+}
+
+/**
+ * Image pasting for Chrome, Firefox and IE 11
+ *
+ * @param {DOMNode} elem
+ * @param {Function} imageCallback - when image is pasted, this callback is called with either Blob representing raw image to upload, or URL on the image
+ * @param {Function} stringCallback - Firefox only - when text is passed, the text is caught and passed through this callback
+ */
+function Paster(elem, imageCallback, stringCallback) {
+  var _self = this;
+  var ctrlPressed = false;
+  var stringPastTimeout;
+  var pasteCatcher;
+  var isWebkit = window.chrome !== null && window.chrome !== undefined;
+
+
+  /**
+   * Constructor
+   */
+  this.init = function () {
+    if (isWebkit) {
+      elem.addEventListener('paste', _self.pasteHandler, true); //official paste handler
+      return;
+    }
+
+    // Content editable div, which catches all pasted data (images and text)
+    pasteCatcher = document.createElement("div");
+    pasteCatcher.setAttribute("id", "paste-catcher");
+    pasteCatcher.setAttribute("contenteditable", "");
+    pasteCatcher.style.cssText = 'opacity:0;position:fixed;top:0px;left:0px;width:10px;margin-left:-20px;';
+    document.body.appendChild(pasteCatcher);
+
+    elem.addEventListener('keydown', _self.onKeyboardAction, false);
+    elem.addEventListener('keyup', _self.onKeyboardUpAction, false);
+    pasteCatcher.addEventListener('paste', _self.pasteFallback);
+
+    // Observer which detects DOM changes in pasteCatcher
+    var observer = new MutationObserver(function (mutations) {
+      mutations.forEach(_self.mutationHandler);
+    });
+    var target = document.getElementById('paste-catcher');
+    var config = {attributes: true, childList: true, characterData: true};
+    observer.observe(target, config);
+  };
+
+  this.mutationHandler = function (mutation) {
+    if (ctrlPressed == false || mutation.type != 'childList') {
+      return true;
+    }
+
+    if (mutation.addedNodes.length == 1) {
+      // Pasted image
+      if (mutation.addedNodes[0].src != undefined) {
+        clearTimeout(stringPastTimeout); // Cancel pasting string
+        var imgSrc = mutation.addedNodes[0].src;
+
+        if (_self.isUrl(imgSrc)) { // src contains link on image
+          imageCallback(imgSrc);
+        } else if (imgSrc.lastIndexOf('data:image', 0) === 0) { // src contains img data in base64
+          var mimeType = /(image\/(png|jpg|jpeg))/g.exec(imgSrc);
+          imgSrc = imgSrc.replace(/^data:image\/(png|jpg|jpeg);base64,/, "");
+          imageCallback(_self.b64toBlob(imgSrc, mimeType[1]));
+        } else { // unknown state
+          console.log("Unknown src format: " + imgSrc);
+        }
+      }
+
+      setTimeout(function () {
+        pasteCatcher.innerHTML = '';
+      }, 20);
+    }
+  };
+
+  /**
+   * Callback for 'paste' event which process image data.
+   *
+   * @param event
+   */
+  this.pasteHandler = function (event) {
+    var items = (event.clipboardData || event.originalEvent.clipboardData).items || event.clipboardData.files;
+    if (items) {
+      for (var i = 0; i < items.length; i++) {
+        if (items[i].type.indexOf("image") !== -1) {
+          var blob = items[i].getAsFile();
+          imageCallback(blob);
+          event.preventDefault();
+        }
+      }
+    }
+  };
+
+  /**
+   * Fallback callback for Firefox for pasting a plain text.
+   * After event is fired, timeout is set to see if the pasted data was image or text.
+   * If it was image, the timeout is cleared by the mutation observer.
+   * If it was not image, the timeout runs out and the text is pasted.
+   *
+   * @param event
+     */
+  this.pasteFallback = function (event) {
+    var text;
+    if(event.clipboardData){ // Firefox
+      text = event.clipboardData.getData("text/plain");
+    }else{ // IE
+      text = window.clipboardData.getData("Text");
+    }
+
+    if(text !== ""){
+      stringPastTimeout = setTimeout(function () {
+        stringCallback(text);
+        event.preventDefault();
+      }, 50);
+    }
+  };
+
+  /**
+   * Callback for detecting CTRL+V keys
+   * @param event
+     */
+  this.onKeyboardAction = function (event) {
+    var key = event.keyCode;
+
+    //ctrl
+    if (key == 17 || event.metaKey || event.ctrlKey) {
+        ctrlPressed = true;
+    }
+
+    //v
+    if (key == 86 && ctrlPressed == true) {
+      pasteCatcher.focus();
+    }
+  };
+
+  //on kaybord release
+  this.onKeyboardUpAction = function (event) {
+    ctrlPressed = false;
+  };
+
+  /**
+   * Convert base64 data into Blob file
+   * @param b64Data
+   * @param contentType
+   * @returns {Blob}
+     */
+  this.b64toBlob = function (b64Data, contentType) {
+    contentType = contentType || '';
+
+    var sliceSize = 512;
+    var byteCharacters = atob(b64Data);
+    var byteArrays = [];
+
+    for (var offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+      var slice = byteCharacters.slice(offset, offset + sliceSize);
+
+      var byteNumbers = new Array(slice.length);
+      for (var i = 0; i < slice.length; i++) {
+        byteNumbers[i] = slice.charCodeAt(i);
+      }
+
+      var byteArray = new Uint8Array(byteNumbers);
+
+      byteArrays.push(byteArray);
+    }
+
+    return new Blob(byteArrays, {type: contentType});
+  };
+
+  /**
+   * Testing string if contains valid URL
+   * @param string
+   * @returns {boolean}
+     */
+  this.isUrl = function (string) {
+    var urlPattern = /\b((?:https?:\/\/|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/i;
+    return urlPattern.test(string);
+  };
+
+  this.init();
 }

--- a/frontend/js/directives/codemirror.js
+++ b/frontend/js/directives/codemirror.js
@@ -192,7 +192,7 @@ function Paster(elem, imageCallback, stringCallback) {
     pasteCatcher = document.createElement("div");
     pasteCatcher.setAttribute("id", "paste-catcher");
     pasteCatcher.setAttribute("contenteditable", "");
-    pasteCatcher.style.cssText = 'opacity:0;position:fixed;top:0px;left:0px;width:10px;margin-left:-20px;';
+    pasteCatcher.style.cssText = 'opacity:0;position:fixed;top:0px;left:0px;width:10px;margin-left:-20px;z-index:1;';
     document.body.appendChild(pasteCatcher);
 
     elem.addEventListener('keydown', _self.onKeyboardAction, false);

--- a/templates/notes/getting_started.md
+++ b/templates/notes/getting_started.md
@@ -88,7 +88,7 @@ $$$
 
 ###1.5. Images
 
-Images can be dragged and dropped over the editor. Alternatively, you can use the standard markdown syntax to insert images.
+Images can be dragged and dropped over the editor. Alternatively, you can copy&paste image data (not files) directly to editor (supported only by Chrome, Firefox and Internet Explorer 11). Lastly, you can use the standard markdown syntax to insert images.
 
 ![](http://i.markdownnotes.com/montreal_xMvtnHZ.jpg)
 


### PR DESCRIPTION
Support for pasting images as described in #1.

I thought that it will be easy to implement, but cross browser compatibility struck again (I really thought that with IE 6-8 dead, that will be no issue :sob: ). Only reasonable solution was in Chrome (which followed the example stated in #1 ), but in the end I also managed to make it work in Firefox and IE11. But in other browser copy&paste should be left intact. Microsoft Edge should have also worked, but I didn't find out the issue...

With future releases of browser this should hopefully improve.
